### PR TITLE
Review recursive path structures when assembling reviewed-properties set

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,6 +42,9 @@ all: \
   monolithic.ttl \
   test_exemplar_coverage.py
 	source $(top_srcdir)/venv/bin/activate \
+	  && python3 -m doctest \
+	    test_exemplar_coverage.py
+	source $(top_srcdir)/venv/bin/activate \
 	  && pytest \
 	    --log-level=DEBUG
 	touch $@

--- a/tests/test_exemplar_coverage.py
+++ b/tests/test_exemplar_coverage.py
@@ -16,10 +16,10 @@
 
 import logging
 from pathlib import Path
-from typing import Optional, Set
+from typing import Generator, Optional, Set
 
-from rdflib import SH, Graph, URIRef
-from rdflib.query import ResultRow
+from rdflib import SH, BNode, Graph, URIRef
+from rdflib.term import IdentifiedNode
 
 NS_SH = SH
 
@@ -76,32 +76,18 @@ def test_exemplar_coverage() -> None:
     result: Optional[bool]
 
     for n_sh_predicate_with_predicate_object in {
-        NS_SH.inversePath,
-        NS_SH.path,
         NS_SH.targetObjectsOf,
         NS_SH.targetSubjectsOf,
-        NS_SH.zeroOrMorePath,
     }:
         for n_object in shapes_graph.objects(
             None, n_sh_predicate_with_predicate_object
         ):
             if isinstance(n_object, URIRef):
                 properties_mapped.add(n_object)
-    for alternative_path_result in shapes_graph.query(
-        """\
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX sh: <http://www.w3.org/ns/shacl#>
-SELECT ?nPredicate
-WHERE {
-  ?nShThing sh:alternativePath ?nAlternativePathList .
-  ?nAlternativePathList rdf:rest*/rdf:first ?nPredicate .
-  FILTER isURI(?nPredicate)
-}
-"""
-    ):
-        assert isinstance(alternative_path_result, ResultRow)
-        assert isinstance(alternative_path_result[0], URIRef)
-        properties_mapped.add(alternative_path_result[0])
+    for n_object in shapes_graph.objects(None, NS_SH.path):
+        assert isinstance(n_object, IdentifiedNode)
+        for n_property in properties_in_shacl_property_path(shapes_graph, n_object):
+            properties_mapped.add(n_property)
 
     property_query = """\
 ASK {
@@ -163,3 +149,91 @@ ASK {
     assert properties_mapped <= (
         properties_with_exemplars | concepts_excused
     ) and classes_mapped <= (classes_with_exemplars | concepts_excused)
+
+
+def properties_in_shacl_property_path(
+    graph: Graph, n_property_path: IdentifiedNode
+) -> Generator[URIRef, None, None]:
+    """
+    https://www.w3.org/TR/shacl/#property-paths
+    >>> import rdflib
+    >>> graph_text = '''
+    ... # Example graph built from: https://www.w3.org/TR/shacl/#property-paths
+    ... PREFIX ex: <http://example.com/ns#>
+    ... PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    ... PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    ... PREFIX sh: <http://www.w3.org/ns/shacl#>
+    ... []
+    ...     a sh:PropertyShape ;
+    ...     sh:path ex:parent ;
+    ...     .
+    ... []
+    ...     a sh:PropertyShape ;
+    ...     sh:path [ sh:inversePath ex:parent ];
+    ...     .
+    ... []
+    ...     a sh:PropertyShape ;
+    ...     sh:path ( ex:parent ex:firstName );
+    ...     .
+    ... []
+    ...     a sh:PropertyShape ;
+    ...     sh:path ( rdf:type [ sh:zeroOrMorePath rdfs:subClassOf ] );
+    ...     .
+    ... []
+    ...     a sh:PropertyShape ;
+    ...     sh:path [ sh:alternativePath ( ex:father ex:mother ) ];
+    ...     .
+    ... '''
+    >>> graph = rdflib.Graph()
+    >>> _ = graph.parse(data=graph_text, format="turtle")
+    >>> ns_ex = rdflib.Namespace("http://example.com/ns#")
+    >>> n_properties_in_graph: set[rdflib.URIRef] = set()
+    >>> for n_property_path in graph.objects(None, rdflib.SH.path):
+    ...     for n_property in properties_in_shacl_property_path(graph, n_property_path):
+    ...         n_properties_in_graph.add(n_property)
+    >>> assert n_properties_in_graph == {
+    ...     ns_ex["father"],
+    ...     ns_ex["firstName"],
+    ...     ns_ex["mother"],
+    ...     ns_ex["parent"],
+    ...     rdflib.RDF["type"],
+    ...     rdflib.RDFS["subClassOf"],
+    ... }
+    """
+    if isinstance(n_property_path, URIRef):
+        yield n_property_path
+    else:
+        assert isinstance(n_property_path, BNode)
+        for n_object in graph.objects(n_property_path, NS_SH.inversePath):
+            assert isinstance(n_object, IdentifiedNode)
+            yield from properties_in_shacl_property_path(graph, n_object)
+        else:
+            for n_object in graph.objects(n_property_path, NS_SH.zeroOrMorePath):
+                assert isinstance(n_object, IdentifiedNode)
+                yield from properties_in_shacl_property_path(graph, n_object)
+            else:
+                for n_object in graph.objects(n_property_path, NS_SH.oneOrMorePath):
+                    assert isinstance(n_object, IdentifiedNode)
+                    yield from properties_in_shacl_property_path(graph, n_object)
+                else:
+                    for n_object in graph.objects(n_property_path, NS_SH.zeroOrOnePath):
+                        assert isinstance(n_object, IdentifiedNode)
+                        yield from properties_in_shacl_property_path(graph, n_object)
+                    else:
+                        for n_object in graph.objects(
+                            n_property_path, NS_SH.alternativePath
+                        ):
+                            assert isinstance(n_object, IdentifiedNode)
+                            for n_alternative_path_member in graph.items(n_object):
+                                assert isinstance(
+                                    n_alternative_path_member, IdentifiedNode
+                                )
+                                yield from properties_in_shacl_property_path(
+                                    graph, n_alternative_path_member
+                                )
+                        else:
+                            for n_sequence_member in graph.items(n_property_path):
+                                assert isinstance(n_sequence_member, IdentifiedNode)
+                                yield from properties_in_shacl_property_path(
+                                    graph, n_sequence_member
+                                )


### PR DESCRIPTION
This patch updates the loop that builds the set of properties involved in shapes.  That set is tested against the properties used in the exemplars graph to confirm exemplars exercise the properties in the SHACL graph.

The `sh:alternativePath` gatherer loop did not address the recursive potential of SHACL property shapes.  This patch adds a function to recurse through the predicates available to property-paths, and more generally enables doctests for the `pytest` script c/o this recursing function having a doctest.

No effects were observed on Make-managed files.

References:
* https://www.w3.org/TR/2017/REC-shacl-20170720/#property-paths