### PR TITLE
Change pinning between "ABox" and shapes graph

### DIFF
--- a/tests/exemplars.ttl
+++ b/tests/exemplars.ttl
@@ -1,4 +1,4 @@
-# imports: http://example.org/shapes/sh-example
+# imports: http://example.org/ontology/example/0.0.1
 
 @prefix drafting: <http://example.org/ontology/drafting/> .
 @prefix ex: <http://example.org/ontology/example/> .
@@ -6,12 +6,14 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <http://example.org/kb>
 	a owl:Ontology ;
 	rdfs:comment "This knowledge base instantiates each of the shape-reviewed classes and properties, so SHACL shapes can be exercised for the reviewed ontology."@en ;
-	owl:imports <http://example.org/shapes/sh-example> ;
+	owl:imports ex:0.0.1 ;
+	sh:shapesGraph <http://example.org/shapes/sh-example> ;
 	.
 
 kb:Object-76f5befa-f5e1-4b2c-8d7b-ea7cf18ecca6


### PR DESCRIPTION
To date, the examples' data graph has referenced the shapes graph, or shapes graph version IRI, of the local shapes repository with `owl:imports`, enabling OWL version-review rules to affirm the imports consistency.  This was done knowingly as a bit of a bend of the semantics of `owl:imports`, favoring the existing version-review system. This was also done without awareness of `sh:shapesGraph`, which turns out to meet the intended linking purpose.

This patch switches the imports to have the "ABox" `owl:imports` the "TBox", and link the shapes graph separately.  Whether there is future change needed for OWL version consistency checking from the shapes graphs' perspectives is left for discussion in the SHACL 1.2 Profiling Task Force.

References:
* https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Imports
* https://www.w3.org/TR/2017/REC-shacl-20170720/#sh-shapes-graph